### PR TITLE
Lookup mimetype by resourcePath if not supplied

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var loaderUtils = require("loader-utils");
+var mime = require("mime");
 module.exports = function(content) {
 	this.cacheable && this.cacheable();
 	var query = loaderUtils.parseQuery(this.query);
@@ -10,11 +11,7 @@ module.exports = function(content) {
 	if(query.limit) {
 		limit = parseInt(query.limit, 10);
 	}
-	var mimetype = null;
-	if(query.minetype)
-		mimetype = query.minetype
-	if(query.mimetype)
-		mimetype = query.mimetype
+	var mimetype = query.mimetype || query.minetype || mime.lookup(this.resourcePath);
 	if(limit <= 0 || content.length < limit) {
 		return "module.exports = " + JSON.stringify("data:" + (mimetype ? mimetype + ";" : "") + "base64," + content.toString("base64"));
 	} else {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"description": "url loader module for webpack",
 	"dependencies": {
 		"file-loader": "0.5.x",
-		"loader-utils": "0.2.x"
+		"loader-utils": "0.2.x",
+		"mime": "1.2.x"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This will lookup the mime type if not supplied with the https://www.npmjs.org/package/mime library. Primarily for convenience so I don't need to specify each within the config: `test: /\.(png|svg|woff|eot|ttf|otf)$/, loader: 'url?limit=100000'`

Sorry for CRLF change in the `package.json` btw.
