### PR TITLE
Export an ES Module instead of CommonJS module

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function(content) {
 	}
 	var mimetype = query.mimetype || query.minetype || mime.lookup(this.resourcePath);
 	if(limit <= 0 || content.length < limit) {
-		return "module.exports = " + JSON.stringify("data:" + (mimetype ? mimetype + ";" : "") + "base64," + content.toString("base64"));
+		return "export default " + JSON.stringify("data:" + (mimetype ? mimetype + ";" : "") + "base64," + content.toString("base64"));
 	} else {
 		var fileLoader = require("file-loader");
 		return fileLoader.call(this, content);


### PR DESCRIPTION
Since webpack v2, it's better to use ES modules. Note that this is incompatible with webpack v1, so it should be released as a major version.
