### PR TITLE
Remove license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Don't hesitate to create a pull request. Every contribution is appreciated. In d
 
 <h2 align="center">LICENSE</h2>
 
-#### [MIT](./LICENSE)
+MIT
 
 [npm]: https://img.shields.io/npm/v/url-loader.svg
 [npm-url]: https://npmjs.com/package/url-loader


### PR DESCRIPTION
To allow inclusion in https://webpack.js.org/ docs.

See https://github.com/webpack/webpack.js.org/pull/804