### PR TITLE
fix: `String` not being `base64` encoded

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(content) {
 
     // No limits or limit more than content length
     if(!limit || content.length < limit) {
-        if(typeof content === 'string') {
+        if(typeof content === "string") {
             content = new Buffer(content);
         }
         return "module.exports = " + JSON.stringify("data:" + (mimetype ? mimetype + ";" : "") + "base64," + content.toString("base64"));

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ module.exports = function(content) {
 
     // No limits or limit more than content length
     if(!limit || content.length < limit) {
+        if(typeof content === 'string') {
+            content = new Buffer(content);
+        }
         return "module.exports = " + JSON.stringify("data:" + (mimetype ? mimetype + ";" : "") + "base64," + content.toString("base64"));
     }
 


### PR DESCRIPTION
Bugfix for strings not being base64 encoded. The specific issue is to do with happypack passing SVGs as strings instead of Buffers causes them to not be encoded properly.