### PR TITLE
fix: don't default to `0` (`options.limit`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,31 @@
 /*
-	MIT License http://www.opensource.org/licenses/mit-license.php
-	Author Tobias Koppers @sokra
-*/
+ MIT License http://www.opensource.org/licenses/mit-license.php
+ Author Tobias Koppers @sokra
+ */
 var loaderUtils = require("loader-utils");
 var mime = require("mime");
+
 module.exports = function(content) {
-	this.cacheable && this.cacheable();
-	var query = loaderUtils.getOptions(this) || {};
-	var limit = (this.options && this.options.url && this.options.url.dataUrlLimit) || 0;
-	if(query.limit) {
-		limit = parseInt(query.limit, 10);
-	}
-	var mimetype = query.mimetype || query.minetype || mime.lookup(this.resourcePath);
-	if(limit <= 0 || content.length < limit) {
-		return "module.exports = " + JSON.stringify("data:" + (mimetype ? mimetype + ";" : "") + "base64," + content.toString("base64"));
-	} else {
-		var fileLoader = require("file-loader");
-		return fileLoader.call(this, content);
-	}
+    this.cacheable && this.cacheable();
+
+    var options =  loaderUtils.getOptions(this) || {};
+    // Options `dataUrlLimit` is backward compatibility with first loader versions
+    var limit = options.limit || (this.options && this.options.url && this.options.url.dataUrlLimit);
+
+    if(limit) {
+        limit = parseInt(limit, 10);
+    }
+
+    var mimetype = options.mimetype || options.minetype || mime.lookup(this.resourcePath);
+
+    // No limits or limit more than content length
+    if(!limit || content.length < limit) {
+        return "module.exports = " + JSON.stringify("data:" + (mimetype ? mimetype + ";" : "") + "base64," + content.toString("base64"));
+    }
+
+    var fileLoader = require("file-loader");
+
+    return fileLoader.call(this, content);
 }
+
 module.exports.raw = true;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Refactoring

**Did you add tests for your changes?**

manual testing :smile: 

**If relevant, did you update the README?**

not required

**Summary**

Consistent getting `limit` options, also don't use 0 as default `limit` value because this is misleading when reading the code: if no `limit` encode all, if `limit` enable encode only files smaller than `limit`.

**Does this PR introduce a breaking change?**

No

**Other information**

not required
