### PR TITLE
Make file-loader an actual dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,9 @@
   "author": "Tobias Koppers @sokra",
   "description": "url loader module for webpack",
   "dependencies": {
+    "file-loader": "^0.11.1",
     "loader-utils": "^1.0.2",
     "mime": "1.3.x"
-  },
-  "peerDependencies": {
-    "file-loader": "*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
This change moves the `file-loader` peer dependency to an actual production dependency

**Did you add tests for your changes?**
No

**If relevant, did you update the README?**
No

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
According to [the official announcement by nodeJS](https://nodejs.org/en/blog/npm/peer-dependencies/), peer dependencies should only be used for plugins. While `url-loader` serves a very similar purpose to `file-loader`, it does not augment or extend `file-loader` and actually serves as a full replacement. That being said, I could always be misunderstanding the purpose of this loader or what the definition of peer dependencies are If I'm totally off base then of course feel free to just close this PR! 

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
I opened a PR instead of an issue so that if you guys agree you can merge it super easily without having to do the silly `npm install` yourselves, and if you disagree you can close it. Thanks for an awesome compiler! 