### PR TITLE
docs(README): fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ module.exports = {
         test: /\.(png|jpg|gif)$/,
         use: [
           {
-            loader: 'url-loader'
+            loader: 'url-loader',
             options: {
               limit: 8192
-            }  
+            }
           }
         ]
       }


### PR DESCRIPTION
Fix typo and remove trailing spaces. Just looks better.