### PR TITLE
fix: allow use `limit` as `{String}`

### DIFF
--- a/options.json
+++ b/options.json
@@ -2,7 +2,7 @@
   "type": "object",
   "properties": {
     "limit": {
-      "type": "number"
+      "type": ["number", "string"]
     },
     "prefix": {
       "type": "string"


### PR DESCRIPTION
### Issues 
---

- Fixes #95 