### PR TITLE
fix(index): use `Buffer.from`  instead of deprecated `new Buffer`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export default function loader(src) {
   // No limit or within the specified limit
   if (!limit || src.length < limit) {
     if (typeof src === 'string') {
-      src = new Buffer(src);
+      src = Buffer.from(src);
     }
 
     return `export default ${JSON.stringify(


### PR DESCRIPTION
Use `Buffer.from(string)` instead of deprecated `new Buffer(string)`.

Requires Node.js >= 4.5.0, but that seems to fit into current version requirements.

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor