### PR TITLE
Readme: add example to set options for fallback loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ Set the MIME type for the file. If unspecified the file extensions will be used 
 }
 ```
 
+The fallback loader will recieve the same configuration options as the url-loader.
+
+Example: To set the quality option of the responsive-loader above use:
+
+```js
+{
+  loader: 'url-loader',
+  options: {
+    fallback: 'responsive-loader',
+    quality: 85
+  }
+}
+```
+
 <h2 align="center">Maintainers</h2>
 
 <table>


### PR DESCRIPTION
Small extension to the readme because it was originally not clear to me how one can set the fallback loader options. Created on suggestion of @evilebottnawi in issue #118.
fixes #118