### PR TITLE
chore(package): use caret range for `schema-utils` (`dependencies`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "webpack": "^4.0.0"
   },
   "dependencies": {
-    "schema-utils": "1.0.0",
     "loader-utils": "^1.1.0",
-    "mime": "^2.0.3"
+    "mime": "^2.0.3",
+    "schema-utils": "^1.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^5.2.5",


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

This will allow url-loader to depend on new, compatible versions of schema-utils as they are released. The other dependencies of url-loader are declared this way. See https://github.com/webpack-contrib/url-loader/pull/136#issuecomment-412967621

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

n/a

### Additional Info