### PR TITLE
fix(utils/normalizeFallback): correctly pass all `options` to the default fallback (`file-loader`)

### DIFF
--- a/src/utils/normalizeFallback.js
+++ b/src/utils/normalizeFallback.js
@@ -7,12 +7,18 @@ function normalizeFallbackString(fallbackString, originalOptions) {
     };
   }
 
-  // To remain consistent with version 1.0.1, pass the options which were provided to url-loader to the fallback loader.
-  // Perhaps it would make sense to strip out ‒ or "consume" ‒ the options we know were meant for url-loader: limit and
-  // mimetype.
+  // To remain consistent with version 1.0.1, pass any other options which were provided to url-loader to the fallback loader.
+  const { fallback, limit, mimetype, ...otherOptions } = originalOptions;
+
+  if (Object.keys(otherOptions).length === 0) {
+    return {
+      loader: fallbackString,
+    };
+  }
+
   return {
     loader: fallbackString,
-    query: originalOptions,
+    query: otherOptions,
   };
 }
 
@@ -35,9 +41,7 @@ function normalizeFallbackObject(fallbackObject) {
 export default function normalizeFallback(fallback, originalOptions) {
   // If no fallback was provided, use file-loader.
   if (!fallback) {
-    return {
-      loader: 'file-loader',
-    };
+    return normalizeFallbackString('file-loader', originalOptions);
   }
 
   if (typeof fallback === 'string') {

--- a/src/utils/normalizeFallback.js
+++ b/src/utils/normalizeFallback.js
@@ -10,12 +10,6 @@ function normalizeFallbackString(fallbackString, originalOptions) {
   // To remain consistent with version 1.0.1, pass any other options which were provided to url-loader to the fallback loader.
   const { fallback, limit, mimetype, ...otherOptions } = originalOptions;
 
-  if (Object.keys(otherOptions).length === 0) {
-    return {
-      loader: fallbackString,
-    };
-  }
-
   return {
     loader: fallbackString,
     query: otherOptions,

--- a/test/options/__snapshots__/fallback.test.js.snap
+++ b/test/options/__snapshots__/fallback.test.js.snap
@@ -7,3 +7,5 @@ exports[`Options fallback {String} 2`] = `"module.exports = __webpack_public_pat
 exports[`Options fallback {String} 3`] = `"module.exports = __webpack_public_path__ + \\"name-for-file-loader.png\\";"`;
 
 exports[`Options fallback {String} 4`] = `"module.exports = __webpack_public_path__ + \\"name-for-file-loader.png\\";"`;
+
+exports[`Options fallback {undefined} 1`] = `"module.exports = __webpack_public_path__ + \\"name-for-url-loader.png\\";"`;

--- a/test/options/fallback.test.js
+++ b/test/options/fallback.test.js
@@ -22,6 +22,23 @@ describe('Options', () => {
       expect(source).toMatchSnapshot();
     });
 
+    test('{undefined}', async () => {
+      const config = {
+        loader: {
+          test: /\.png$/,
+          options: {
+            limit: 100,
+            name: 'name-for-url-loader.[ext]',
+          },
+        },
+      };
+
+      const stats = await webpack('fixture.js', config);
+      const { source } = stats.toJson().modules[0];
+
+      expect(source).toMatchSnapshot();
+    });
+
     // Version 1.0.1 passes options provided to url-loader to the fallback as well, so make sure that still works.
     test('{String}', async () => {
       const config = {

--- a/test/utils/__snapshots__/normalizeFallback.test.js.snap
+++ b/test/utils/__snapshots__/normalizeFallback.test.js.snap
@@ -20,7 +20,6 @@ exports[`normalizeFallback string 1`] = `
 Object {
   "loader": "file-loader",
   "query": Object {
-    "limit": 8192,
     "name": "name-for-url-loader.[ext]",
   },
 }
@@ -36,5 +35,8 @@ Object {
 exports[`normalizeFallback undefined 1`] = `
 Object {
   "loader": "file-loader",
+  "query": Object {
+    "name": "name-for-url-loader.[ext]",
+  },
 }
 `;


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Fixes #138 by passing on all non-`url-loader` options when defaulting to `file-loader` as the fallback.

This also implements the suggestion which was previously in a code comment to strip out url-loader specific options when passing them to the fallback - this shouldn't be a breaking change as they were never accepted by `file-loader`.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

Should undo a breaking change for people who depended on options being passed on to `file-loader` 😹 

### Additional Info

❤️ 