### PR TITLE
Add default fallback to 'file-loader'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ export default function loader(src) {
 
   // Normalize the fallback.
   const { loader: fallbackLoader, query: fallbackQuery } = normalizeFallback(
-    options.fallback,
+    options.fallback || 'file-loader',
     options
   );
 


### PR DESCRIPTION
It seems the update to v1.1.0 removed the default `fallback` to `file-loader`. This adds it again.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

It's documented that the default `fallback` is `file-loader`.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info