### PR TITLE
fix(package): add support for `webpack =< v3.0.0` (`peerDependencies`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "webpack": "^4.0.0"
+    "webpack": "^3.0.0||^4.0.0"
   },
   "dependencies": {
     "loader-utils": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "webpack": "^3.0.0||^4.0.0"
+    "webpack": "^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "loader-utils": "^1.1.0",


### PR DESCRIPTION
It was unexpectedly introduced in https://github.com/webpack-contrib/url-loader/commit/9946374885ec01578ad692a386c82e08b3a9c1e7

See https://github.com/webpack-contrib/url-loader/commit/9946374885ec01578ad692a386c82e08b3a9c1e7#r30474904

### Type

- [x] Fix

### Issues

- Fixes #147

### SemVer

- [x] Patch