### PR TITLE
Allow mimetype as function

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,12 @@ The limit can be specified via loader options and defaults to no limit.
 
 ### `mimetype`
 
-Type: `String`
+Type: `String|Function`
 Default: `(file extension)`
 
-Sets the MIME type for the file to be transformed. If unspecified the file
+Sets the MIME type for the file to be transformed. If a function is provided, 
+it'll get pass the resource file path so that you can decide the correct mimetype
+dynamically. If unspecified, or the function return falsy value, the file
 extensions will be used to lookup the MIME type.
 
 ```js
@@ -125,7 +127,13 @@ extensions will be used to lookup the MIME type.
 {
   loader: 'url-loader',
   options: {
-    mimetype: 'image/png'
+    mimetype: 'image/png',
+    // or
+    mimetype: (file) => {
+      if (file.endsWith('.png') {
+        return 'image/png';
+      }
+    }
   }
 }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,13 @@ export default function loader(src) {
     limit = parseInt(limit, 10);
   }
   // Get MIME type
-  const mimetype = options.mimetype || mime.getType(file);
+  let mimetype;
+  if (options.mimetype && typeof options.mimetype === 'string') {
+    mimetype = options.mimetype;
+  } else if (typeof options.mimetype === 'function') {
+    mimetype = options.mimetype(file);
+  }
+  if (!mimetype) mimetype = mime.getType(file);
 
   // No limit or within the specified limit
   if (!limit || src.length < limit) {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

In case user need to specify multiple __custom mimetype__ based on file name, currently it requires a work around like below:

```js
const fontMimetypeMap = {
  woff: 'application/font-woff',
  woff2: 'application/font-woff2',
  otf: 'font/opentype',
  ttf: 'application/octet-stream',
  eot: 'application/vnd.ms-fontobject',
  svg: 'image/svg+xml'
};

const fontLoaderRules = Object.keys(fontMimetypeMap).map(ext => {
  return {
    test: new RegExp(`\\.${ext}`),
    loader: 'url-loader',
    options: {
      mimetype: fontMimetypeMap[ext]
    }
  };
});

webpackConfig.module.rules = webpackConfig.module.rules.concat(fontLoaderRules);
```

If we allow `mimetype` option as a function, we get:

```js
const oneRuleForAllAssets = {
  test: /\.(png|jpg|gif|svg|woff|woff2|otf|ttf|eot)$/,
  loader: 'url-loader',
  options: {
    mimetype: (file) => {
      const ext = file.substr(file.lastIndexOf('.')+1);
      switch (ext) {
        case 'woff': return 'application/font-woff';
        case 'woff2': return 'application/font-woff2';
        case 'otf': return 'font/opentype';
        case 'ttf': return 'application/octet-stream';
        case 'eot': return 'application/vnd.ms-fontobject';
      }
      return undefined;  // falsy value returned will fallback to `mime.getType(file)` internally
    }
  }
};
```

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

None, it's backward compatible.

### Additional Info

None.