### PR TITLE
fix: peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,13 @@
     "dist"
   ],
   "peerDependencies": {
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0",
+    "file-loader": "*"
+  },
+  "peerDependenciesMeta": {
+    "file-loader": {
+      "optional": true
+    }
   },
   "dependencies": {
     "loader-utils": "^1.2.3",


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

fix peer deps

### Breaking Changes

No

### Additional Info

/cc @arcanis 

need your advice in this situation, by default we use `file-loader` if we can't decode content to `base64` (limit option), but we allow to setup custom fallback (https://github.com/webpack-contrib/url-loader#fallback, allow to use any other loader), so we can't setup right peer deps in this case. What we should do?